### PR TITLE
Don't save step context during restart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.33</version>
     <relativePath />
   </parent>
 
@@ -43,6 +43,10 @@
         <exclusion>
           <groupId>org.apache.maven.wagon</groupId>
           <artifactId>wagon-ftp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>symbol-annotation</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
https://github.com/jenkinsci/junit-realtime-test-reporter-plugin/pull/18#discussion_r773459098

I've tested this manually and code paths work correctly and it's no longer saved in the `build.xml`

Bit convoluted though =/