### PR TITLE
Add optional attribute to set the junit results parse interval

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/AbstractRealtimeTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/AbstractRealtimeTestResultAction.java
@@ -49,12 +49,10 @@ abstract class AbstractRealtimeTestResultAction extends AbstractTestResultAction
 
     @Override
     public TestResult getResult() {
-        // Refresh every 1/100 of a job estimated duration but not more often than every 5 seconds
-        final long threshold = Math.max(5000, run.getEstimatedDuration() / 100);
+        final long threshold = getParseInterval();
         // TODO possible improvements:
         // · always run parse in case result == null
         // · run parse regardless of cache if result.getTotalCount() == 0
-        // · refresh no less often than every 1m even if job is estimated to take >100m
         if (updated > System.currentTimeMillis() - threshold && !Main.isUnitTest) {
             LOGGER.fine("Cache hit");
             return result;
@@ -80,6 +78,13 @@ abstract class AbstractRealtimeTestResultAction extends AbstractTestResultAction
             LOGGER.log(Level.WARNING, "Unable to parse", ex);
         }
         return result;
+    }
+
+    protected long getParseInterval() {
+        // Refresh every 1/100 of a job estimated duration but not more often than every 5 seconds
+        return Math.max(5000, run.getEstimatedDuration() / 100);
+        // TODO possible improvements:
+        // · refresh no less often than every 1m even if job is estimated to take >100m
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/PipelineRealtimeTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/PipelineRealtimeTestResultAction.java
@@ -55,13 +55,15 @@ class PipelineRealtimeTestResultAction extends AbstractRealtimeTestResultAction 
     private final String glob;
     @CheckForNull
     private transient final StepContext context;
+    private final Long parseInterval;
 
     PipelineRealtimeTestResultAction(
             String id,
             FilePath ws,
             boolean keepLongStdio,
             String glob,
-            StepContext context
+            StepContext context,
+            Long parseInterval
     ) {
         this.id = id;
         node = FilePathUtils.getNodeName(ws);
@@ -69,6 +71,7 @@ class PipelineRealtimeTestResultAction extends AbstractRealtimeTestResultAction 
         this.keepLongStdio = keepLongStdio;
         this.glob = glob;
         this.context = context;
+        this.parseInterval = parseInterval;
     }
 
     @Override
@@ -84,6 +87,11 @@ class PipelineRealtimeTestResultAction extends AbstractRealtimeTestResultAction 
     @Override
     public String getUrlName() {
         return "realtimeTestReport-" + id;
+    }
+
+    @Override
+    protected long getParseInterval() {
+        return parseInterval != null ? parseInterval.longValue() : super.getParseInterval();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
@@ -139,8 +139,12 @@ public class RealtimeJUnitStep extends Step {
 
     @DataBoundSetter
     public void setParseInterval(Long parseInterval) {
-        if (parseInterval == null || parseInterval.longValue() > 0) {
-            this.parseInterval = parseInterval;
+        if (parseInterval != null && parseInterval.longValue() > 0) {
+            // Configuration value is in seconds, parse interval is stored in milliseconds
+            this.parseInterval = parseInterval.longValue() * 1000;
+        } else {
+            // Explicit value not set (or negative), dynamically calculated value will be used
+            this.parseInterval = null;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
@@ -76,6 +76,7 @@ public class RealtimeJUnitStep extends Step {
     private Double healthScaleFactor;
     private boolean allowEmptyResults;
     private boolean skipMarkingBuildUnstable;
+    private Long parseInterval;
 
     @DataBoundConstructor
     public RealtimeJUnitStep(String testResults) {
@@ -132,6 +133,17 @@ public class RealtimeJUnitStep extends Step {
         this.skipMarkingBuildUnstable = skipMarkingBuildUnstable;
     }
 
+    public Long getParseInterval() {
+        return parseInterval;
+    }
+
+    @DataBoundSetter
+    public void setParseInterval(Long parseInterval) {
+        if (parseInterval == null || parseInterval.longValue() > 0) {
+            this.parseInterval = parseInterval;
+        }
+    }
+
     @Override
     public StepExecution start(StepContext context) throws Exception {
         JUnitResultArchiver delegate = new JUnitResultArchiver(testResults);
@@ -140,16 +152,18 @@ public class RealtimeJUnitStep extends Step {
         delegate.setKeepLongStdio(keepLongStdio);
         delegate.setTestDataPublishers(getTestDataPublishers());
         delegate.setSkipMarkingBuildUnstable(isSkipMarkingBuildUnstable());
-        return new Execution2(context, delegate);
+        return new Execution2(context, delegate, parseInterval);
     }
 
     @SuppressFBWarnings("SE_BAD_FIELD") // FIXME
     static class Execution2 extends GeneralNonBlockingStepExecution {
         private final JUnitResultArchiver archiver;
+        private final Long parseInterval;
 
-        Execution2(StepContext context, JUnitResultArchiver archiver) {
+        Execution2(StepContext context, JUnitResultArchiver archiver, Long parseInterval) {
             super(context);
             this.archiver = archiver;
+            this.parseInterval = parseInterval;
         }
 
         @Override
@@ -168,7 +182,8 @@ public class RealtimeJUnitStep extends Step {
                             context.get(FilePath.class),
                             archiver.isKeepLongStdio(),
                             archiver.getTestResults(),
-                            context
+                            context,
+                            parseInterval
                     )
             );
             AbstractRealtimeTestResultAction.saveBuild(r);
@@ -249,7 +264,8 @@ public class RealtimeJUnitStep extends Step {
                             context.get(FilePath.class),
                             archiver.isKeepLongStdio(),
                             archiver.getTestResults(),
-                            context
+                            context,
+                            null
                     )
             );
             AbstractRealtimeTestResultAction.saveBuild(r);

--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
@@ -139,13 +139,7 @@ public class RealtimeJUnitStep extends Step {
 
     @DataBoundSetter
     public void setParseInterval(Long parseInterval) {
-        if (parseInterval != null && parseInterval.longValue() > 0) {
-            // Configuration value is in seconds, parse interval is stored in milliseconds
-            this.parseInterval = parseInterval.longValue() * 1000;
-        } else {
-            // Explicit value not set (or negative), dynamically calculated value will be used
-            this.parseInterval = null;
-        }
+        this.parseInterval = parseInterval;
     }
 
     @Override
@@ -156,6 +150,8 @@ public class RealtimeJUnitStep extends Step {
         delegate.setKeepLongStdio(keepLongStdio);
         delegate.setTestDataPublishers(getTestDataPublishers());
         delegate.setSkipMarkingBuildUnstable(isSkipMarkingBuildUnstable());
+        // step takes value in milliseconds but users provide in seconds
+        Long parseInterval = this.parseInterval != null ? this.parseInterval * 1000 : null;
         return new Execution2(context, delegate, parseInterval);
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep/config.jelly
@@ -24,8 +24,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <!-- like f:property but without actually using a nested object (see main class for discussion): -->
-    <j:set var="descriptor" value="${descriptor.delegateDescriptor}"/>
-    <st:include from="${descriptor}" page="${descriptor.configPage}"/>
+    <j:set var="delegateDescriptor" value="${descriptor.delegateDescriptor}"/>
+    <st:include from="${delegateDescriptor}" page="${delegateDescriptor.configPage}"/>
+    <f:entry title="${%Parse Interval}" field="parseInterval">
+        <f:number/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep/help-parseInterval.html
+++ b/src/main/resources/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep/help-parseInterval.html
@@ -1,0 +1,7 @@
+<div>
+    <p>
+        The interval between 2 file system scans to parse test results (in milliseconds).
+        Must be a positive value greater than 0.
+        Default value is calculated as 1/100 of the estimated build duration, but never more often than every 5 seconds.
+    </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep/help-parseInterval.html
+++ b/src/main/resources/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep/help-parseInterval.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        The interval between 2 file system scans to parse test results (in milliseconds).
+        The interval between two file system scans to parse test results (in seconds).
         Must be a positive value greater than 0.
         Default value is calculated as 1/100 of the estimated build duration, but never more often than every 5 seconds.
     </p>


### PR DESCRIPTION

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Adding an optional attribute to set the junit results parse interval.
When the value is not set, the previous default logic is applied.

Fixes #21 

I did not add unit tests, this is hard to test, but here is some output to prove it works:

Configuration page:

![image](https://user-images.githubusercontent.com/595214/147985858-4af562a7-5432-4884-a3d2-c839498e9228.png)

Logging output when the parse interval is not set (never more often then every 5 seconds)

```
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.PipelineRealtimeTestResultAction
parsing *.xml in /var/jenkins_home/workspace/junitrealtime on node  for junitrealtime #5
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Parsing of 4 test results took 7ms
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:07 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:08 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:09 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:10 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:11 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 9:57:14 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.PipelineRealtimeTestResultAction
parsing *.xml in /var/jenkins_home/workspace/junitrealtime on node  for junitrealtime #5
Jan 03, 2022 9:57:14 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Parsing of 4 test results took 6ms

```

Logging output when the parse interval is set to 500 (milliseconds)

```
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.PipelineRealtimeTestResultAction
parsing *.xml in /var/jenkins_home/workspace/junitrealtime on node  for junitrealtime #6
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Parsing of 4 test results took 5ms
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:25 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.PipelineRealtimeTestResultAction
parsing *.xml in /var/jenkins_home/workspace/junitrealtime on node  for junitrealtime #6
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Parsing of 4 test results took 5ms
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Cache hit
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.PipelineRealtimeTestResultAction
parsing *.xml in /var/jenkins_home/workspace/junitrealtime on node  for junitrealtime #6
Jan 03, 2022 10:13:26 PM FINE org.jenkinsci.plugins.junitrealtimetestreporter.AbstractRealtimeTestResultAction
Parsing of 4 test results took 5ms

```
