### PR TITLE
Use `XStream2` where possible

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/junitrealtimetestreporter/storage/H2JunitTestResultStorage.java
+++ b/src/test/java/org/jenkinsci/plugins/junitrealtimetestreporter/storage/H2JunitTestResultStorage.java
@@ -18,6 +18,7 @@ import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultSummary;
 import hudson.tasks.junit.TrendTestResultSummary;
 import hudson.tasks.test.PipelineTestDetails;
+import hudson.util.XStream2;
 import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.JunitTestResultStorageDescriptor;
 import io.jenkins.plugins.junit.storage.TestResultImpl;
@@ -731,7 +732,7 @@ public class H2JunitTestResultStorage extends JunitTestResultStorage {
      */
     static class RemoteConnectionSupplier extends ConnectionSupplier implements SerializableOnlyOverRemoting {
 
-        private static final XStream XSTREAM = new XStream();
+        private static final XStream XSTREAM = new XStream2();
         private final String databaseXml;
 
         static {


### PR DESCRIPTION
While working on a different core PR, I noticed this plugin was using vanilla XStream rather than the Jenkins-specific XStream2 in one test. Since we generally prefer XStream2, and since using XStream2 doesn't make the test start failing, I thought it would be best to make this usage consistent with our general preference for XStream2.