### PR TITLE
Replace keepLongStdio property with stdioRetention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,14 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+
+      <!-- TODO: Remove once BOM is bumped to a version that pulls this in
+           automatically -->
+      <dependency>
+        <groupId>io.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1259.v65ffcef24a_88</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
+
+      <!-- TODO: Remove explicit version once BOM is bumped to a version that
+           pulls this in automatically -->
+      <version>1259.v65ffcef24a_88</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -146,14 +150,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- TODO: Remove once BOM is bumped to a version that pulls this in
-           automatically -->
-      <dependency>
-        <groupId>io.jenkins-ci.plugins</groupId>
-        <artifactId>junit</artifactId>
-        <version>1259.v65ffcef24a_88</version>
-      </dependency>
-
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,6 @@
     <jenkins.version>2.387.3</jenkins.version>
     <!-- Using JUnit pluggable storage -->
     <useBeta>true</useBeta>
-
-    <junit-plugin.version>1259.v65ffcef24a_88</junit-plugin.version>
   </properties>
 
   <dependencies>
@@ -148,6 +146,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- TODO: Remove once BOM is bumped to a version that pulls this in
+           automatically -->
+      <dependency>
+        <groupId>io.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1259.v65ffcef24a_88</version>
+      </dependency>
+
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <jenkins.version>2.387.3</jenkins.version>
     <!-- Using JUnit pluggable storage -->
     <useBeta>true</useBeta>
+
+    <junit-plugin.version>1259.v65ffcef24a_88</junit-plugin.version>
   </properties>
 
   <dependencies>
@@ -152,14 +154,6 @@
         <version>2543.vfb_1a_5fb_9496d</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-
-      <!-- TODO: Remove once BOM is bumped to a version that pulls this in
-           automatically -->
-      <dependency>
-        <groupId>io.jenkins-ci.plugins</groupId>
-        <artifactId>junit</artifactId>
-        <version>1259.v65ffcef24a_88</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStep.java
@@ -421,7 +421,9 @@ public class RealtimeJUnitStep extends Step {
         // seem to pick up doFillXxxItems methods automatically, so we have to explicitly
         // delegate to the JUnitResultArchiver's descriptor class
         public ListBoxModel doFillStdioRetentionItems(@QueryParameter("stdioRetention") String value) {
-            return new JUnitResultArchiver.DescriptorImpl().doFillStdioRetentionItems(value);
+            JUnitResultArchiver.DescriptorImpl descriptor = Jenkins.get()
+                    .getDescriptorByType(JUnitResultArchiver.DescriptorImpl.class);
+            return descriptor.doFillStdioRetentionItems(value);
         }
 
     }

--- a/src/test/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStepTest.java
@@ -208,6 +208,8 @@ public class RealtimeJUnitStepTest {
                 rr.j.assertEqualDataBoundBeans(s, t.configRoundTrip(s));
                 s.setKeepLongStdio(true);
                 rr.j.assertEqualDataBoundBeans(s, t.configRoundTrip(s));
+                s.setStdioRetention("FAILED");
+                rr.j.assertEqualDataBoundBeans(s, t.configRoundTrip(s));
                 s.setSkipMarkingBuildUnstable(true);
                 rr.j.assertEqualDataBoundBeans(s, t.configRoundTrip(s));
         });


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This ports upstream changes from the JUnit plugin that replaced the `keepLongStdio` property with `stdioRetention` in https://github.com/jenkinsci/junit-plugin/pull/601. Without this change, this plugin is incompatible with newer releases of the JUnit plugin.

### Testing done

I tweaked the POM to use the [latest release](https://github.com/jenkinsci/junit-plugin/releases/tag/1259.v65ffcef24a_88) of the JUnit plugin, then ran existing unit tests. As reported [elsewhere](https://github.com/jenkinsci/junit-plugin/pull/601#issuecomment-1925356113), the `RealtimeJUnitStepTest::ui` case failed. After these changes, that test succeeded, and I was able to verify that the UI contains the correct values for the property in the dropdown form. For good measure, I also added another round trip config test with a new value for the `stdioRetention` property.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

