### PR TITLE
Allow PCT testing with `database-sqlite`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/junitrealtimetestreporter/RealtimeJUnitStepTest.java
@@ -91,8 +91,11 @@ public class RealtimeJUnitStepTest {
 
     public void autoServer() throws Exception {
         if (usePluggableStorage) {
-            LocalH2Database database = (LocalH2Database) GlobalDatabaseConfiguration.get().getDatabase();
-            GlobalDatabaseConfiguration.get().setDatabase(new LocalH2Database(database.getPath(), true));
+            GlobalDatabaseConfiguration gdc = GlobalDatabaseConfiguration.get();
+            gdc.setDatabase(null);
+            LocalH2Database.setDefaultGlobalDatabase();
+            LocalH2Database database = (LocalH2Database) gdc.getDatabase();
+            gdc.setDatabase(new LocalH2Database(database.getPath(), true));
             JunitTestResultStorageConfiguration.get().setStorage(new H2JunitTestResultStorage());
         }
     }


### PR DESCRIPTION
Discovered in https://github.com/jenkinsci/bom/pull/3057 when trying to add `database-sqlite` to BOM. Both SQLite and H2 database plugins attempt to set themselves as the default, and when SQLite wins then this test fails. Fixed by changing the test to not make any assumptions about the default and instead explicitly set the database to the one the test expects.

### Testing done

Tested in context in PCT. Passes after this PR.